### PR TITLE
Only inject fs_mitm when overlay files are actually present for the title

### DIFF
--- a/fs_mitm/source/fsmitm_service.hpp
+++ b/fs_mitm/source/fsmitm_service.hpp
@@ -22,7 +22,14 @@ class FsMitMService : public IMitMServiceObject {
         }
         
         static bool should_mitm(u64 pid, u64 tid) {
-            return tid >= 0x0100000000010000ULL || Utils::HasSdMitMFlag(tid);
+            if(!(tid >= 0x0100000000010000ULL || Utils::HasSdMitMFlag(tid))) return false;
+            
+            FsDir tst;
+            char slash = '/';
+            bool ret = R_SUCCEEDED(Utils::OpenSdDirForAtmosphere(tid, &slash, &tst));
+            if(!ret) return false;
+            fsDirClose(&tst);
+            return true;
         }
         
         FsMitMService *clone() override {


### PR DESCRIPTION
This transparently works around the Okami save freeze (actually trying to use layeredFS with Okami will still freeze) and should avoid similar compatibility problems. There may be positive performance implications as well.