### PR TITLE
Enable pm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KIPS := loader sm
+KIPS := loader sm pm
 
 SUBFOLDERS := libstratosphere $(KIPS)
 


### PR DESCRIPTION
v1.6 is supposed to ship with pm (at least according to the changelog) but it seems like it's not there.

This PR enables builds for it.