### PR TITLE
Fix for version string

### DIFF
--- a/rnx_mitm/source/set_mitm/setsys_firmware_version.cpp
+++ b/rnx_mitm/source/set_mitm/setsys_firmware_version.cpp
@@ -61,7 +61,7 @@ void VersionManager::Initialize() {
     {
         char display_version[sizeof(g_ams_fw_version.display_version)] = {0};
         
-        snprintf(display_version, sizeof(display_version), "%s ReiNX(%s.%s)", g_ams_fw_version.display_version, VERSION_MAJOR, VERSION_MINOR);
+        snprintf(display_version, sizeof(display_version), "%s ReiNX(%d.%d)", g_ams_fw_version.display_version, VERSION_MAJOR, VERSION_MINOR);
 
         memcpy(g_ams_fw_version.display_version, display_version, sizeof(g_ams_fw_version.display_version));
     }


### PR DESCRIPTION
When compiled from ReiNX repo caused black screen after ReiNX splash screen.

Fixed as discussed in discord.